### PR TITLE
Fix pluralization of 'Standort' / 'Standorten'

### DIFF
--- a/src/Views.elm
+++ b/src/Views.elm
@@ -115,6 +115,14 @@ aboutView =
         ]
 
 
+pluralize : String -> String -> Int -> String
+pluralize singular plural quantity =
+    if quantity == 1 then
+        singular
+    else
+        plural
+
+
 {-| View: Map
 -}
 mapView : Model -> Html Msg
@@ -122,7 +130,8 @@ mapView model =
     page
         ("Finde die aktuelle und historische Wassertemperatur an "
             ++ (model.sensors |> List.length |> toString)
-            ++ " Standorten rund um den Zürichsee!"
+            ++ (pluralize " Standort" " Standorten" (model.sensors |> List.length))
+            ++ " rund um den Zürichsee!"
         )
         [ div [ css [ position absolute, top (px 8), right (px 8) ] ]
             [ a


### PR DESCRIPTION
Previously it showed "1 Standorten".