### PR TITLE
Fix routing

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -75,31 +75,33 @@ update msg model =
             ( { model | now = Just newTime }, Cmd.none )
 
         LinkClicked urlRequest ->
-            ( model, Cmd.none )
+            case urlRequest of
+                Browser.External href ->
+                    ( model, Nav.load href )
+
+                Browser.Internal url ->
+                    ( model, Nav.pushUrl model.key (Url.toString url) )
 
         UrlChanged url ->
-            ( model, Cmd.none )
+            let
+                -- Determine the new route by parsing the location
+                newRoute =
+                    toRoute url
 
-        --        UrlChanged url ->
-        --            let
-        --                -- Determine the new route by parsing the location
-        --                newRoute =
-        --                    parseLocation location
-        --
-        --                -- Determine any side effects (e.g. map init) caused by the location change
-        --                cmd =
-        --                    case newRoute of
-        --                        MapRoute ->
-        --                            -- Re-initialize map
-        --                            MapPort.initializeMap model.map
-        --
-        --                        AboutRoute ->
-        --                            Cmd.none
-        --
-        --                        NotFoundRoute ->
-        --                            Cmd.none
-        --            in
-        --            ( { model | route = newRoute }, cmd )
+                -- Determine any side effects (e.g. map init) caused by the location change
+                cmd =
+                    case newRoute of
+                        Routing.MapRoute ->
+                            MapPort.initializeMap model.map
+
+                        Routing.AboutRoute ->
+                            Cmd.none
+
+                        Routing.NotFoundRoute ->
+                            Cmd.none
+            in
+            ( { model | route = newRoute }, cmd )
+
         MapInitialized _ ->
             ( model, Api.loadSensors model.apiToken )
 

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -10,7 +10,7 @@ const elmApp = entrypoint.Elm.Main.init({
     },
 });
 
-elmApp.ports.initializeMap.subscribe((pos) => {
+const initializeMap = (pos) => {
     console.info('Map: Initialize');
 
     // Check whether WebGL is supported
@@ -153,4 +153,8 @@ elmApp.ports.initializeMap.subscribe((pos) => {
 
     // Notify Elm that the map has been initialized
     elmApp.ports.mapInitialized.send(null);
+};
+
+elmApp.ports.initializeMap.subscribe((pos) => {
+    window.requestAnimationFrame(() => initializeMap(pos));
 });


### PR DESCRIPTION
- Handle internal and external url changes
- Reinitialize map when navigating to the map view
- Run map initialization inside `requestAnimationFrame` to ensure that
  the map element is already present