### PR TITLE
Drop float string parsing support

### DIFF
--- a/src/elm/Api.elm
+++ b/src/elm/Api.elm
@@ -1,7 +1,6 @@
 module Api exposing
     ( apiTimeout
     , errorToString
-    , floatAsStringDecoder
     , getHeaders
     , getUrl
     , loadSensorMeasurements
@@ -61,28 +60,12 @@ sponsorDecoder =
         |> Pipeline.optional "active" Decode.bool False
 
 
-{-| Parse a string as float. Fail if parsing does not succeed.
--}
-floatAsStringDecoder : Decode.Decoder Float
-floatAsStringDecoder =
-    Decode.string
-        |> Decode.andThen
-            (\str ->
-                case String.toFloat str of
-                    Just parsed ->
-                        Decode.succeed parsed
-
-                    Nothing ->
-                        Decode.fail "Could not parse string value as float"
-            )
-
-
 measurementDecoder : Decode.Decoder Measurement
 measurementDecoder =
     Decode.succeed Measurement
         |> Pipeline.required "id" Decode.int
         |> Pipeline.required "sensor_id" (Decode.nullable Decode.int)
-        |> Pipeline.required "temperature" floatAsStringDecoder
+        |> Pipeline.required "temperature" Decode.float
         |> Pipeline.required "created_at" DecodeExtra.datetime
 
 

--- a/tests/ApiTests.elm
+++ b/tests/ApiTests.elm
@@ -149,7 +149,7 @@ suite =
                                     """
                                         { "id": 1
                                         , "sensor_id": 3
-                                        , "temperature": "27.3"
+                                        , "temperature": 27.3
                                         , "created_at": "2016-11-29T20:35:21.813Z"
                                         , "updated_at": "2016-11-29T20:36:48.016Z"
                                         }


### PR DESCRIPTION
The API will not deliver decimal strings anymore but floats.

This has to be deployed together with https://github.com/gfroerli/api/pull/66
Can you do that @dbrgn? We don't have auto-deployment, right?

Oh, and did we have build failures lately? I don't think this is related to my changes. I think `Skinney/murmur3` is not reachable for our old Elm version anymore.