### PR TITLE
update URLs after repo move: coredump-ch/water-sensor-web → gfroerli/web

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,5 +70,5 @@ Licensed under the AGPLv3 or later, see `LICENSE.md`.
 
 
 <!-- Badges -->
-[circle-ci]: https://circleci.com/gh/coredump-ch/water-sensor-web/tree/master
-[circle-ci-badge]: https://circleci.com/gh/coredump-ch/water-sensor-web/tree/master.svg?style=shield
+[circle-ci]: https://circleci.com/gh/gfroerli/web/tree/master
+[circle-ci-badge]: https://circleci.com/gh/gfroerli/web/tree/master.svg?style=shield

--- a/src/elm/Routing.elm
+++ b/src/elm/Routing.elm
@@ -47,7 +47,7 @@ aboutPath =
 
 githubPath : String
 githubPath =
-    "https://github.com/coredump-ch/water-sensor-web"
+    "https://github.com/gfroerli/web"
 
 
 coredumpPath : String


### PR DESCRIPTION
Update URLs after repository was moved on GitHub from [`coredump-ch/water-sensor-web`](https://github.com/coredump-ch/water-sensor-web) to [`gfroerli/web`](https://github.com/gfroerli/web/).