### PR TITLE
Dev server: Fallback to webapp

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -4,6 +4,9 @@ const common = require('./webpack.common.js');
 const config = merge(common, {
     mode: 'development',
     devtool: 'inline-source-map',
+    devServer: {
+        historyApiFallback: true,
+    },
 });
 
 module.exports = config;


### PR DESCRIPTION
This allows URLs like /about to work.

The live version needed a change to the nginx config that is now implemented.

Fixes #62.