### PR TITLE
Hide inactive sensors

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -228,5 +228,5 @@ subscriptions model =
         , MapPort.mapInitializationFailed MapInitializationFailed
         , MapPort.mapMoved MapDragged
         , MapPort.sensorClicked SensorClicked
-        , Time.every (10 * 1000) TimeUpdate
+        , Time.every (10 * 1000) TimeUpdate -- Update current time every 10 seconds
         ]

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -109,8 +109,25 @@ update msg model =
             ( Models.addErrorAlert model alertMsg, Cmd.none )
 
         SensorsLoaded (Ok sensors) ->
-            ( { model | selectedSensor = Nothing, sensors = sensors }
-            , List.map Api.toJsSensor sensors
+            -- Filter sensors, exclude sensors that haven't sent any measurements in more than 7 days
+            let
+                maxMeasurementAgeMillis =
+                    7 * 24 * 60 * 60 * 1000
+
+                filteredSensors =
+                    List.filter
+                        (\sensor ->
+                            case ( model.now, sensor.latestMeasurementAt ) of
+                                ( Just now, Just latestMeasurementAt ) ->
+                                    (Time.posixToMillis now - Time.posixToMillis latestMeasurementAt) < maxMeasurementAgeMillis
+
+                                _ ->
+                                    False
+                        )
+                        sensors
+            in
+            ( { model | selectedSensor = Nothing, sensors = filteredSensors }
+            , List.map Api.toJsSensor filteredSensors
                 |> MapPort.sensorsLoaded
             )
 

--- a/src/elm/Models.elm
+++ b/src/elm/Models.elm
@@ -1,6 +1,5 @@
 module Models exposing
     ( Alert
-    , JsMeasurement
     , JsSensor
     , Measurement
     , Model
@@ -59,9 +58,10 @@ type alias Sensor =
     , caption : Maybe String
     , latitude : Float
     , longitude : Float
-    , sponsorId : Maybe Int
     , createdAt : Time.Posix
-    , lastMeasurement : Maybe Measurement
+    , sponsorId : Maybe Int
+    , latestTemperature : Maybe Float
+    , latestMeasurementAt : Maybe Time.Posix
     , historicMeasurements : Maybe (List Measurement)
     }
 
@@ -78,7 +78,7 @@ type alias JsSensor =
     , deviceName : String
     , caption : Maybe String
     , pos : Map.Pos
-    , lastMeasurement : Maybe JsMeasurement
+    , latestTemperature : Maybe Float
     }
 
 
@@ -87,9 +87,4 @@ type alias Measurement =
     , sensorId : Maybe Int
     , temperature : Float
     , createdAt : Time.Posix
-    }
-
-
-type alias JsMeasurement =
-    { temperature : Float
     }

--- a/src/elm/Views.elm
+++ b/src/elm/Views.elm
@@ -305,12 +305,12 @@ sensorDescription now sensor sponsor =
             )
             -- Extract and show last measurement
             (Maybe.map
-                (\measurement ->
+                (\temperature ->
                     p
                         [ css [ fontStyle normal ] ]
-                        [ text (measurement.temperature |> String.fromFloat |> formatTemperature) ]
+                        [ text (temperature |> String.fromFloat |> formatTemperature) ]
                 )
-                sensor.lastMeasurement
+                sensor.latestTemperature
             )
         , h3 [] [ text "Temperaturverlauf (3 Tage)" ]
         , Maybe.withDefault

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -104,8 +104,8 @@ const initializeMap = (pos) => {
             const el = document.createElement('div');
             el.className = 'marker';
             let text;
-            if (sensor.lastMeasurement) {
-                const tempString = sensor.lastMeasurement.temperature;
+            if (sensor.latestTemperature) {
+                const tempString = sensor.latestTemperature;
                 const tempFloat = parseFloat(tempString);
                 if (!!tempFloat) {
                     text = document.createTextNode(Math.round(tempFloat));

--- a/tests/ApiTests.elm
+++ b/tests/ApiTests.elm
@@ -2,12 +2,12 @@ module ApiTests exposing (suite)
 
 import Api exposing (getHeaders, measurementDecoder, sensorDecoder)
 import Expect exposing (FloatingPointTolerance(..))
-import Fuzz exposing (Fuzzer, int, list, string)
 import Http
 import Iso8601
 import Json.Decode as Decode exposing (errorToString)
 import Result.Extra exposing (unpack)
 import Test exposing (Test, describe, test)
+import Time
 
 
 suite : Test
@@ -34,8 +34,9 @@ suite =
                                     , "latitude": 1.00
                                     , "longitude": 2.00
                                     , "sponsor_id": null
-                                    , "created_at": "2016-11-29T20:35:21.813Z"
-                                    , "updated_at": "2016-11-29T20:36:48.016Z"
+                                    , "created_at": 1670632950
+                                    , "latest_temperature": null
+                                    , "latest_measurement_at": null
                                     }
                                     """
                         in
@@ -60,8 +61,9 @@ suite =
                                     , "latitude": 1.00
                                     , "longitude": 2.00
                                     , "sponsor_id": 7
-                                    , "created_at": "2016-11-29T20:35:21.813Z"
-                                    , "updated_at": "2016-11-29T20:36:48.016Z"
+                                    , "created_at": 1670632950
+                                    , "latest_temperature": 13.37
+                                    , "latest_measurement_at": 1670632960
                                     }
                                     """
                         in
@@ -74,11 +76,9 @@ suite =
                                 , \sensor -> Expect.equal sensor.latitude 1.0
                                 , \sensor -> Expect.equal sensor.longitude 2.0
                                 , \sensor -> Expect.equal sensor.sponsorId (Just 7)
-                                , \sensor ->
-                                    Iso8601.toTime "2016-11-29T20:35:21.813Z"
-                                        |> unpack
-                                            (\_ -> Expect.fail "Could not parse createdAt expectation date")
-                                            (\expected -> Expect.equal sensor.createdAt expected)
+                                , \sensor -> Expect.equal sensor.createdAt (Time.millisToPosix 1670632950000)
+                                , \sensor -> Expect.equal sensor.latestTemperature (Just 13.37)
+                                , \sensor -> Expect.equal sensor.latestMeasurementAt (Just (Time.millisToPosix 1670632960000))
                                 ]
                             )
                             result
@@ -94,8 +94,9 @@ suite =
                                     , "latitude": 1.00
                                     , "longitude": 2.00
                                     , "sponsor_id": null
-                                    , "created_at": "2016-11-29T20:35:21.813Z"
-                                    , "updated_at": "2016-11-29T20:36:48.016Z"
+                                    , "created_at": 1670632950
+                                    , "latest_temperature": null
+                                    , "latest_measurement_at": null
                                     , "blergh": "blubh"
                                     }
                                     """
@@ -117,8 +118,9 @@ suite =
                                     , "latitude": 1.00
                                     , "longitude": 2.00
                                     , "sponsor_id": null
-                                    , "created_at": "2016-11-29T20:35:21.813Z"
-                                    , "updated_at": "2016-11-29T20:36:48.016Z"
+                                    , "created_at": 1670632950
+                                    , "latest_temperature": null
+                                    , "latest_measurement_at": null
                                     , "blergh": "blubh"
                                     }
                                     """


### PR DESCRIPTION
Hide sensors that haven't sent a measurement during the last 7 days.

(It's a bit longer than originally specified in #89, but this avoids hiding the sensors too fast if there's a short outage.)

Fixes #89.