### PR TITLE
Add apple-app-site-association to well-known

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,0 +1,13 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "T7M5358433.ch.coredump.gfroerli",
+        "paths": [
+          "/"
+        ]
+      }
+    ]
+  }
+}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -42,7 +42,7 @@ module.exports = {
             minfy: false,
         }),
         new CopyWebpackPlugin({
-            patterns: [ { from: 'static', to: 'static' } ],
+            patterns: [ { from: 'static', to: 'static' }, { from: '.well-known', to: '.well-known' } ],
         }),
     ],
 


### PR DESCRIPTION
To allow general deeplinking whenever a user with the iOS App installed taps on a https://gfrör.li link we must add this file.
For doc see: 
https://developer.apple.com/documentation/xcode/supporting-associated-domains
[medium](https://medium.com/@musmein/associated-domains-78843817f1eb)