### PR TITLE
Sensor permalinks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+[*.{yml,html,css}]
+indent_size = 2

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -101,21 +101,11 @@ update msg model =
 
                 -- Determine any side effects (e.g. map init) caused by the location change
                 cmd =
-                    case newRoute of
-                        Routing.MapRoute ->
-                            MapPort.initializeMap model.map
+                    if not (routeNeedsMap model.route) && routeNeedsMap newRoute then
+                        MapPort.initializeMap model.map
 
-                        Routing.SensorRoute _ ->
-                            MapPort.initializeMap model.map
-
-                        Routing.AboutRoute ->
-                            Cmd.none
-
-                        Routing.PrivacyPolicyRoute ->
-                            Cmd.none
-
-                        Routing.NotFoundRoute ->
-                            Cmd.none
+                    else
+                        Cmd.none
             in
             ( { model | route = newRoute }, cmd )
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -55,8 +55,8 @@ init flags url key =
       , map = map
       , sensors = []
       , initialSensorId = initialSensorId
-      , selectedSensor = Models.SensorMissing
-      , selectedSponsor = Models.SponsorMissing
+      , selectedSensor = Models.NoSensor
+      , selectedSponsor = Models.NoSponsor
       , apiToken = flags.apiToken
       , now = Nothing
       , alerts = []
@@ -168,7 +168,7 @@ update msg model =
                             )
 
                         Nothing ->
-                            ( { modelWithSensors | selectedSensor = Models.SensorMissing }, cmdsBase )
+                            ( { modelWithSensors | selectedSensor = Models.NoSensor }, cmdsBase )
             in
             ( finalModel, Cmd.batch cmds )
 
@@ -220,7 +220,7 @@ update msg model =
                 -- measurements matches its id.
                 sensor =
                     case model.selectedSensor of
-                        Models.SensorMissing ->
+                        Models.NoSensor ->
                             Nothing
 
                         Models.SensorLoading ->
@@ -279,7 +279,7 @@ update msg model =
             ( { model | selectedSensor = Models.SensorLoading }, loadSensor model jsSensor )
 
         SensorClicked Nothing ->
-            ( { model | selectedSensor = Models.SensorMissing }, Cmd.none )
+            ( { model | selectedSensor = Models.NoSensor }, Cmd.none )
 
 
 {-| Load sensor and sponsor details for the given sensor.

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -266,11 +266,20 @@ update msg model =
             in
             ( { model | map = newMap }, Cmd.none )
 
+        -- Sensor selected
         SensorClicked (Just jsSensor) ->
-            ( { model | selectedSensor = Models.SensorLoading }, loadSensor model jsSensor )
+            ( { model | selectedSensor = Models.SensorLoading }
+            , Cmd.batch
+                [ Nav.pushUrl model.key (Routing.sensorPath jsSensor.id)
+                , loadSensor model jsSensor
+                ]
+            )
 
+        -- Sensor deselected
         SensorClicked Nothing ->
-            ( { model | selectedSensor = Models.NoSensor }, Cmd.none )
+            ( { model | selectedSensor = Models.NoSensor }
+            , Nav.pushUrl model.key Routing.mapPath
+            )
 
 
 {-| Load sensor and sponsor details for the given sensor.

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -7,7 +7,7 @@ import Map
 import MapPort
 import Messages exposing (..)
 import Models exposing (Model)
-import Routing exposing (toRoute)
+import Routing exposing (routeNeedsMap, toRoute)
 import Task
 import Time exposing (posixToMillis)
 import Url
@@ -43,6 +43,9 @@ init flags url key =
 
         currentRoute =
             toRoute url
+
+        currentRouteNeedsMap =
+            routeNeedsMap currentRoute
     in
     ( { key = key
       , route = currentRoute
@@ -55,9 +58,16 @@ init flags url key =
       , alerts = []
       }
     , Cmd.batch
-        [ MapPort.initializeMap map
-        , Task.perform TimeUpdate Time.now
-        ]
+        -- Note: Initialize map only if needed. The TimeUpdate task on the other
+        -- hand is always needed.
+        (if currentRouteNeedsMap then
+            [ MapPort.initializeMap map
+            , Task.perform TimeUpdate Time.now
+            ]
+
+         else
+            [ Task.perform TimeUpdate Time.now ]
+        )
     )
 
 

--- a/src/elm/Map.elm
+++ b/src/elm/Map.elm
@@ -10,9 +10,9 @@ type alias Model =
 
 init : Model
 init =
-    { lat = 47.227099
-    , lng = 8.822077
-    , zoom = 12.0
+    { lat = 47.099859
+    , lng = 8.655552
+    , zoom = 10.0
     }
 
 

--- a/src/elm/MapPort.elm
+++ b/src/elm/MapPort.elm
@@ -18,7 +18,13 @@ import Models
 port initializeMap : Map.Model -> Cmd msg
 
 
-port sensorsLoaded : List Models.JsSensor -> Cmd msg
+{-| Pass sensors to JS.
+
+First parameter: List of all sensors.
+Second parameter: Optional initially selected sensor.
+
+-}
+port sensorsLoaded : ( List Models.JsSensor, Maybe Models.JsSensor ) -> Cmd msg
 
 
 

--- a/src/elm/Models.elm
+++ b/src/elm/Models.elm
@@ -33,13 +33,13 @@ type alias Alert =
 type DelayedSensorDetails
     = SensorLoaded SensorDetails
     | SensorLoading
-    | SensorMissing
+    | NoSensor
 
 
 type DelayedSponsor
     = SponsorLoaded Sponsor
     | SponsorLoading
-    | SponsorMissing
+    | NoSponsor
 
 
 {-| Add an error alert message to the model.

--- a/src/elm/Models.elm
+++ b/src/elm/Models.elm
@@ -10,9 +10,11 @@ module Models exposing
     , Severity(..)
     , Sponsor
     , addErrorAlert
+    , findJsSensorWithId
     )
 
 import Browser.Navigation as Nav
+import List.Extra
 import Map
 import Routing exposing (Route)
 import Time
@@ -58,6 +60,7 @@ type alias Model =
     , route : Route
     , map : Map.Model
     , sensors : List Sensor
+    , initialSensorId : Maybe Int
     , selectedSensor : DelayedSensorDetails
     , selectedSponsor : DelayedSponsor
     , apiToken : String
@@ -112,6 +115,13 @@ type alias JsSensor =
     , pos : Map.Pos
     , latestTemperature : Maybe Float
     }
+
+
+{-| Given an (optional) sensor ID, find the corresponding sensor in the list of JS sensors.
+-}
+findJsSensorWithId : Maybe Int -> List JsSensor -> Maybe JsSensor
+findJsSensorWithId maybeId sensors =
+    Maybe.andThen (\id -> List.Extra.find (\sensor -> sensor.id == id) sensors) maybeId
 
 
 type alias Measurement =

--- a/src/elm/Routing.elm
+++ b/src/elm/Routing.elm
@@ -5,6 +5,7 @@ module Routing exposing
     , githubPath
     , mapPath
     , privacyPolicyPath
+    , routeNeedsMap
     , toRoute
     )
 
@@ -31,6 +32,18 @@ routeParser =
 toRoute : Url.Url -> Route
 toRoute url =
     Maybe.withDefault NotFoundRoute (parse routeParser url)
+
+
+{-| Return whether or not this route requires an initialized map.
+-}
+routeNeedsMap : Route -> Bool
+routeNeedsMap route =
+    case route of
+        MapRoute ->
+            True
+
+        _ ->
+            False
 
 
 

--- a/src/elm/Routing.elm
+++ b/src/elm/Routing.elm
@@ -2,19 +2,22 @@ module Routing exposing
     ( Route(..)
     , aboutPath
     , coredumpPath
+    , getSensorId
     , githubPath
     , mapPath
     , privacyPolicyPath
     , routeNeedsMap
+    , sensorPath
     , toRoute
     )
 
 import Url
-import Url.Parser exposing (Parser, map, oneOf, parse, s, top)
+import Url.Parser exposing ((</>), Parser, int, map, oneOf, parse, s, top)
 
 
 type Route
     = MapRoute
+    | SensorRoute Int
     | AboutRoute
     | PrivacyPolicyRoute
     | NotFoundRoute
@@ -24,6 +27,7 @@ routeParser : Parser (Route -> a) a
 routeParser =
     oneOf
         [ map MapRoute top
+        , map SensorRoute (s "sensor" </> int)
         , map AboutRoute (s "about")
         , map PrivacyPolicyRoute (s "privacy-policy")
         ]
@@ -42,8 +46,21 @@ routeNeedsMap route =
         MapRoute ->
             True
 
+        SensorRoute _ ->
+            True
+
         _ ->
             False
+
+
+getSensorId : Route -> Maybe Int
+getSensorId route =
+    case route of
+        SensorRoute sensorId ->
+            Just sensorId
+
+        _ ->
+            Nothing
 
 
 
@@ -53,6 +70,11 @@ routeNeedsMap route =
 mapPath : String
 mapPath =
     "/"
+
+
+sensorPath : Int -> String
+sensorPath sensorId =
+    "/sensor/" ++ String.fromInt sensorId
 
 
 aboutPath : String

--- a/src/elm/Views.elm
+++ b/src/elm/Views.elm
@@ -29,6 +29,9 @@ view model =
                 MapRoute ->
                     mapView model
 
+                SensorRoute id ->
+                    mapView model
+
                 AboutRoute ->
                     aboutView
 

--- a/src/elm/Views.elm
+++ b/src/elm/Views.elm
@@ -11,7 +11,7 @@ import Html.Styled.Attributes exposing (alt, css, href, id, src)
 import Material.Icons.Outlined as Outlined
 import Material.Icons.Types exposing (Coloring(..))
 import Messages exposing (..)
-import Models exposing (Alert, DelayedSponsor, Model, SensorDetails, Severity(..))
+import Models exposing (Alert, DelayedSensorDetails(..), DelayedSponsor, Model, SensorDetails, Severity(..))
 import Routing exposing (Route(..))
 import Time
 
@@ -41,7 +41,13 @@ view model =
                 NotFoundRoute ->
                     notFoundView
     in
-    { title = "Gfrörli – Wassertemperatur Schweiz"
+    { title =
+        case model.selectedSensor of
+            SensorLoaded details ->
+                "Gfrörli – " ++ details.deviceName ++ " – Wassertemperatur Schweiz"
+
+            _ ->
+                "Gfrörli – Wassertemperatur Schweiz"
     , body = [ toUnstyled body ]
     }
 

--- a/src/elm/Views.elm
+++ b/src/elm/Views.elm
@@ -7,7 +7,7 @@ import Css.Global as Global
 import Css.Media as Media
 import Helpers exposing (approximateTimeAgo, formatTemperature, posixTimeDeltaSeconds)
 import Html.Styled exposing (Attribute, Html, a, div, footer, fromUnstyled, h1, h2, h3, img, li, p, span, text, toUnstyled, ul)
-import Html.Styled.Attributes exposing (alt, css, href, id, src)
+import Html.Styled.Attributes exposing (alt, css, href, id, src, title)
 import Material.Icons.Outlined as Outlined
 import Material.Icons.Types exposing (Coloring(..))
 import Messages exposing (..)
@@ -375,7 +375,10 @@ sidebarContents model =
             ]
 
         ( Models.SensorLoaded sensor, Just now ) ->
-            [ h2 headingStyle [ text sensor.deviceName ]
+            [ div [ css [ displayFlex, flexDirection row, justifyContent spaceBetween ] ]
+                [ h2 headingStyle [ text sensor.deviceName ]
+                , a [ href (Routing.sensorPath sensor.id), title "Permalink" ] [ fromUnstyled <| Outlined.link 16 Inherit ]
+                ]
             , sensorDescription now
                 sensor
                 model.selectedSponsor

--- a/src/elm/Views.elm
+++ b/src/elm/Views.elm
@@ -353,7 +353,7 @@ sidebarContents model =
             [ css [ marginBottom (em 0.5) ] ]
     in
     case ( model.selectedSensor, model.now ) of
-        ( Models.SensorMissing, _ ) ->
+        ( Models.NoSensor, _ ) ->
             [ h2 headingStyle [ text "Details" ]
             , p [] [ text "Klicke auf einen Sensor, um mehr über ihn zu erfahren." ]
             ]
@@ -464,7 +464,7 @@ sensorDescription now sensor sponsor =
             _ ->
                 h3 [] [ text "Sponsor" ]
         , case sponsor of
-            Models.SponsorMissing ->
+            Models.NoSponsor ->
                 p [ css [ fontStyle italic ] ] [ text "Kein Sponsor gefunden" ]
 
             Models.SponsorLoading ->

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -18,7 +18,8 @@ module.exports = {
 
     output: {
         path: path.resolve(__dirname + '/dist'),
-        filename: '[name].[contenthash].js'
+        filename: '[name].[contenthash].js',
+        publicPath: '/'
     },
 
     module: {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -7,6 +7,9 @@ const config = merge(common, {
     devServer: {
         historyApiFallback: true,
     },
+    output: {
+        publicPath: '/',
+    },
 });
 
 module.exports = config;

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -3,6 +3,9 @@ const common = require('./webpack.common.js');
 
 const config = merge(common, {
     mode: 'production',
+    output: {
+        publicPath: '/',
+    },
 });
 
 module.exports = config;


### PR DESCRIPTION
Add a direct URL to sensors: `/sensor/<sensorId>`.

- [x] Add new route for sensors
- [x] Process this URL on page load and show sensor in side panel
- [x] Highlight sensor on map and zoom to it
- [x] Update URL when selecting sensor on map

Fixes #20.

Follow-up tasks:

- URL driven state: #123