### PR TITLE
Update aasa format

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,13 +1,15 @@
 {
   "applinks": {
-    "apps": [],
-    "details": [
-      {
-        "appID": "T7M5358433.ch.coredump.gfroerli",
-        "paths": [
-          "/"
-        ]
-      }
-    ]
-  }
+      "details": [
+           {
+             "appIDs": [ "T7M5358433.ch.coredump.gfroerli"],
+             "components": [
+               {
+                  "/": "/*",
+                  "comment": "Matches any URL."
+               }
+             ]
+           }
+       ]
+   }
 }


### PR DESCRIPTION
The apple app site associated got a new format a while ago. This PR updates it to the new one.